### PR TITLE
Update ai module compiler plugin to support generate API calls when the ai import is not present in the file

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ icon="icon.png"
 name = "ai.openai"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.openai"
-version = "1.2.0"
+version = "1.2.1"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.openai-native"
-version = "1.2.0"
-path = "../native/build/libs/ai.openai-native-1.2.0.jar"
+version = "1.2.1"
+path = "../native/build/libs/ai.openai-native-1.2.1-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-compiler-plugin"
 class = "io.ballerina.lib.ai.openai.AiOpenAICompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.openai-compiler-plugin-1.2.0.jar"
+path = "../compiler-plugin/build/libs/ai.openai-compiler-plugin-1.2.1-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.7"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.openai"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/tests/test-generate-method-usage-in-file-without-ai-import.bal
+++ b/ballerina/tests/test-generate-method-usage-in-file-without-ai-import.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Config
+function testGenerateMethodUsageInFileWithoutAiImport() returns error? {
+    Review|error result = provider->generate(`Please rate this blog out of ${"10"}.
+        Title: ${blog2.title}
+        Content: ${blog2.content}`);
+    test:assertEquals(result, reviewRecord);
+}

--- a/ballerina/tests/test_values.bal
+++ b/ballerina/tests/test_values.bal
@@ -49,6 +49,11 @@ const sampleImageUrl = "https://example.com/image.jpg";
 
 const review = "{\"rating\": 8, \"comment\": \"Talks about essential aspects of sports performance " +
         "including warm-up, form, equipment, and nutrition.\"}";
+        
+const reviewRecord = {
+    rating: 8,
+    comment: "Talks about essential aspects of sports performance including warm-up, form, equipment, and nutrition."
+};
 
 final readonly & map<anydata>[] expectedContentPartsForRateBlog = [
     {


### PR DESCRIPTION
Update ai module compiler plugin to support generate API calls when the ai import is not present in the file

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8126