### PR TITLE
Fix generate method failure for text chunk

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 authors = ["Ballerina"]
 distribution = "2201.12.0"
-keywords = ["Agent", "Model", "Provider", "Vendor/OpenAI", "Area/AI & Machine Learning", "Type/Library"]
+keywords = ["Agent", "Model", "Provider", "Vendor/OpenAI", "Area/AI & Machine Learning", "Type/Connector"]
 license = ["Apache-2.0"]
 icon="icon.png"
 name = "ai.openai"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.openai"
-version = "1.3.2"
+version = "1.3.3"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.openai-native"
-version = "1.3.2"
-path = "../native/build/libs/ai.openai-native-1.3.2.jar"
+version = "1.3.3"
+path = "../native/build/libs/ai.openai-native-1.3.3-SNAPSHOT.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Ballerina"]
 distribution = "2201.12.0"
-keywords = ["Agent", "Model", "Provider", "Vendor/OpenAI", "Area/AI & Machine Learning", "Type/Connector"]
+keywords = ["Agent", "Model", "Provider", "Vendor/OpenAI", "Area/AI & Machine Learning", "Type/Library"]
 license = ["Apache-2.0"]
 icon="icon.png"
 name = "ai.openai"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-compiler-plugin"
 class = "io.ballerina.lib.ai.openai.AiOpenAICompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.openai-compiler-plugin-1.3.2.jar"
+path = "../compiler-plugin/build/libs/ai.openai-compiler-plugin-1.3.3-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -93,7 +93,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -93,7 +93,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.5.3"
+version = "1.5.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.10"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.openai"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -124,14 +124,14 @@ isolated function generateChatCreationContent(ai:Prompt prompt)
         anydata insertion = insertions[i];
         string str = strings[i + 1];
 
-        if insertion is ai:Document {
+        if insertion is ai:Document|ai:Chunk {
             addTextContentPart(buildTextContentPart(accumulatedTextContent), contentParts);
             accumulatedTextContent = "";
             check addDocumentContentPart(insertion, contentParts);
-        } else if insertion is ai:Document[] {
+        } else if insertion is (ai:Document|ai:Chunk)[] {
             addTextContentPart(buildTextContentPart(accumulatedTextContent), contentParts);
             accumulatedTextContent = "";
-            foreach ai:Document doc in insertion {
+            foreach ai:Document|ai:Chunk doc in insertion {
                 check addDocumentContentPart(doc, contentParts);
             }
         } else {
@@ -144,8 +144,8 @@ isolated function generateChatCreationContent(ai:Prompt prompt)
     return contentParts;
 }
 
-isolated function addDocumentContentPart(ai:Document doc, DocumentContentPart[] contentParts) returns ai:Error? {
-    if doc is ai:TextDocument {
+isolated function addDocumentContentPart(ai:Document|ai:Chunk doc, DocumentContentPart[] contentParts) returns ai:Error? {
+    if doc is ai:TextDocument|ai:TextChunk {
         return addTextContentPart(buildTextContentPart(doc.content), contentParts);
     } else if doc is ai:ImageDocument {
         return contentParts.push(check buildImageContentPart(doc));

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -49,6 +49,14 @@ isolated function getExpectedParameterSchema(string message) returns map<json> {
         return expectedParameterSchemaStringForRateBlog2;
     }
 
+    if message.startsWith("How would you rate these text chunks") {
+        return expectedParameterSchemaStringForRateBlog5;
+    }
+
+    if message.startsWith("How would you rate this text chunk") {
+        return expectedParameterSchemaStringForRateBlog;
+    }
+
     if message.startsWith("How would you rate this") {
         return expectedParameterSchemaStringForRateBlog;
     }
@@ -122,7 +130,7 @@ isolated function getExpectedParameterSchema(string message) returns map<json> {
     }
 
     if message.startsWith("Give me a random joke") {
-        return {"type":"object","properties":{"result":{"anyOf":[{"type":"string"},{"type":"null"}]}}};
+        return {"type": "object", "properties": {"result": {"anyOf": [{"type": "string"}, {"type": "null"}]}}};
     }
 
     if message.startsWith("Name a random world class cricketer in India") {
@@ -192,6 +200,14 @@ isolated function getTheMockLLMResult(string message) returns string {
 
     if message.startsWith("How would you rate this text blog") {
         return review;
+    }
+
+    if message.startsWith("How would you rate these text chunks") {
+        return string `{"result": [${review}, ${review}]}`;
+    }
+
+    if message.startsWith("How would you rate this text chunk") {
+        return {result: 4}.toJsonString();
     }
 
     if message.startsWith("How would you rate this") {
@@ -312,6 +328,14 @@ isolated function getExpectedContentParts(string message) returns map<anydata>[]
         return expectedContentPartsForRateBlog8;
     }
 
+    if message.startsWith("How would you rate these text chunks") {
+        return expectedContentPartsForTextChunkArray;
+    }
+
+    if message.startsWith("How would you rate this text chunk") {
+        return expectedContentPartsForTextChunk;
+    }
+
     if message.startsWith("How would you rate this") {
         return expectedContentPartsForRateBlog5;
     }
@@ -338,14 +362,14 @@ isolated function getExpectedContentParts(string message) returns map<anydata>[]
                 "type": "image_url",
                 "image_url": {
                     "url": string `data:image/png;base64,${sampleBase64Str}`,
-                    "detail":"auto"
+                    "detail": "auto"
                 }
             },
             {
                 "type": "image_url",
                 "image_url": {
                     "url": sampleImageUrl,
-                    "detail":"auto"
+                    "detail": "auto"
                 }
             },
             {"type": "text", "text": "."}
@@ -359,7 +383,7 @@ isolated function getExpectedContentParts(string message) returns map<anydata>[]
                 "type": "image_url",
                 "image_url": {
                     "url": string `data:image/png;base64,${sampleBase64Str}`,
-                    "detail":"auto"
+                    "detail": "auto"
                 }
             },
             {
@@ -377,7 +401,7 @@ isolated function getExpectedContentParts(string message) returns map<anydata>[]
                 "type": "image_url",
                 "image_url": {
                     "url": string `data:image/png;base64,${sampleBase64Str}`,
-                    "detail":"auto"
+                    "detail": "auto"
                 }
             },
             {
@@ -394,7 +418,7 @@ isolated function getExpectedContentParts(string message) returns map<anydata>[]
                 "type": "image_url",
                 "image_url": {
                     "url": string `data:image/*;base64,${sampleBase64Str}`,
-                    "detail":"auto"
+                    "detail": "auto"
                 }
             },
             {"type": "text", "text": "."}
@@ -408,7 +432,7 @@ isolated function getExpectedContentParts(string message) returns map<anydata>[]
                 "type": "image_url",
                 "image_url": {
                     "url": sampleImageUrl,
-                    "detail":"auto"
+                    "detail": "auto"
                 }
             },
             {"type": "text", "text": "."}
@@ -422,7 +446,7 @@ isolated function getExpectedContentParts(string message) returns map<anydata>[]
                 "type": "image_url",
                 "image_url": {
                     "url": "This-is-not-a-valid-url",
-                    "detail":"auto"
+                    "detail": "auto"
                 }
             },
             {"type": "text", "text": "."}
@@ -436,7 +460,7 @@ isolated function getExpectedContentParts(string message) returns map<anydata>[]
                 "type": "input_audio",
                 "input_audio": {
                     "data": sampleBase64Str,
-                    "format":"mp3"
+                    "format": "mp3"
                 }
             },
             {"type": "text", "text": "."}
@@ -450,14 +474,14 @@ isolated function getExpectedContentParts(string message) returns map<anydata>[]
                 "type": "input_audio",
                 "input_audio": {
                     "data": sampleBase64Str,
-                    "format":"mp3"
+                    "format": "mp3"
                 }
             },
             {
                 "type": "input_audio",
                 "input_audio": {
                     "data": sampleBase64Str,
-                    "format":"mp3"
+                    "format": "mp3"
                 }
             },
             {"type": "text", "text": "."}
@@ -477,7 +501,7 @@ isolated function getExpectedContentParts(string message) returns map<anydata>[]
     }
 
     if message.startsWith("Name top 10 world class cricketers") {
-        return [{"type": "text", "text": "Name top 10 world class cricketers"}]; 
+        return [{"type": "text", "text": "Name top 10 world class cricketers"}];
     }
 
     if message.startsWith("Name a random world class cricketer in India") {

--- a/ballerina/tests/test_values.bal
+++ b/ballerina/tests/test_values.bal
@@ -150,11 +150,9 @@ final readonly & map<anydata>[] expectedContentPartsForCountry = [
     {"type": "text", "text": "Which country is known as the pearl of the Indian Ocean?"}
 ];
 
-const expectedParameterSchemaStringForRateBlog =
-    {"type": "object", "properties": {"result": {"type": "integer"}}};
+const expectedParameterSchemaStringForRateBlog = {"type": "object", "properties": {"result": {"type": "integer"}}};
 
-const expectedParameterSchemaStringForRateBlog2 =
-    {
+const expectedParameterSchemaStringForRateBlog2 = {
     "type": "object",
     "required": ["comment", "rating"],
     "properties": {
@@ -163,11 +161,9 @@ const expectedParameterSchemaStringForRateBlog2 =
     }
 };
 
-const expectedParameterSchemaStringForRateBlog3 =
-    {"type": "object", "properties": {"result": {"type": "boolean"}}};
+const expectedParameterSchemaStringForRateBlog3 = {"type": "object", "properties": {"result": {"type": "boolean"}}};
 
-const expectedParameterSchemaStringForRateBlog4 =
-    {
+const expectedParameterSchemaStringForRateBlog4 = {
     "type": "object",
     "properties": {
         "result": {
@@ -181,8 +177,7 @@ const expectedParameterSchemaStringForRateBlog4 =
     }
 };
 
-const expectedParameterSchemaStringForRateBlog5 =
-    {
+const expectedParameterSchemaStringForRateBlog5 = {
     "type": "object",
     "properties": {
         "result": {
@@ -199,8 +194,7 @@ const expectedParameterSchemaStringForRateBlog5 =
     }
 };
 
-const expectedParameterSchemaStringForRateBlog6 =
-    {
+const expectedParameterSchemaStringForRateBlog6 = {
     "type": "object",
     "properties": {
         "result": {
@@ -212,8 +206,7 @@ const expectedParameterSchemaStringForRateBlog6 =
     }
 };
 
-const expectedParameterSchemaStringForRateBlog7 =
-    {
+const expectedParameterSchemaStringForRateBlog7 = {
     "type": "object",
     "properties": {
         "result": {
@@ -225,14 +218,11 @@ const expectedParameterSchemaStringForRateBlog7 =
     }
 };
 
-const expectedParameterSchemaStringForRateBlog8 =
-    {"type": "object", "properties": {"result": {"type": "string"}}};
+const expectedParameterSchemaStringForRateBlog8 = {"type": "object", "properties": {"result": {"type": "string"}}};
 
-const expectedParamterSchemaStringForCountry =
-    {"type": "object", "properties": {"result": {"type": "string"}}};
+const expectedParamterSchemaStringForCountry = {"type": "object", "properties": {"result": {"type": "string"}}};
 
-const expectedParamSchemaForArrayUnionNull =
-    {
+const expectedParamSchemaForArrayUnionNull = {
     "type": "object",
     "properties": {
         "result": {
@@ -259,8 +249,7 @@ const expectedParamSchemaForArrayUnionNull =
     }
 };
 
-const expectedParameterSchemaForArrayUnionRec =
-    {
+const expectedParameterSchemaForArrayUnionRec = {
     "type": "object",
     "properties": {
         "result": {
@@ -295,8 +284,7 @@ const expectedParameterSchemaForArrayUnionRec =
     }
 };
 
-const expectedParameterSchemaForArrayUnionBasicType =
-    {
+const expectedParameterSchemaForArrayUnionBasicType = {
     "type": "object",
     "properties": {
         "result": {
@@ -323,8 +311,7 @@ const expectedParameterSchemaForArrayUnionBasicType =
     }
 };
 
-const expectedParameterSchemaForArrayOnly =
-    {
+const expectedParameterSchemaForArrayOnly = {
     "type": "object",
     "properties": {
         "result": {
@@ -344,8 +331,7 @@ const expectedParameterSchemaForArrayOnly =
     }
 };
 
-const expectedParameterSchemaForRecUnionBasicType =
-    {
+const expectedParameterSchemaForRecUnionBasicType = {
     "type": "object",
     "properties": {
         "result": {
@@ -369,8 +355,7 @@ const expectedParameterSchemaForRecUnionBasicType =
     }
 };
 
-const expectedParameterSchemaForRecUnionNull =
-    {
+const expectedParameterSchemaForRecUnionNull = {
     "type": "object",
     "properties": {
         "result": {

--- a/ballerina/tests/test_values.bal
+++ b/ballerina/tests/test_values.bal
@@ -49,7 +49,7 @@ const sampleImageUrl = "https://example.com/image.jpg";
 
 const review = "{\"rating\": 8, \"comment\": \"Talks about essential aspects of sports performance " +
         "including warm-up, form, equipment, and nutrition.\"}";
-        
+
 const reviewRecord = {
     rating: 8,
     comment: "Talks about essential aspects of sports performance including warm-up, form, equipment, and nutrition."
@@ -233,53 +233,13 @@ const expectedParamterSchemaStringForCountry =
 
 const expectedParamSchemaForArrayUnionNull =
     {
-        "type": "object",
-        "properties": {
-            "result": {
-                "anyOf": [
-                    {
-                        "type": "array",
-                        "items": {
-                            "required": [
-                                "name"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "type": "null"
-                    }
-                ]
-            }
-        }
-    };
-
-const expectedParameterSchemaForArrayUnionRec =
-    {
-        "type": "object",
-        "properties": {
-            "result": {
-                "anyOf": [
-                    {
-                        "type": "array",
-                        "items": {
-                            "required": [
-                                "name"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    {
+    "type": "object",
+    "properties": {
+        "result": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
                         "required": [
                             "name"
                         ],
@@ -290,46 +250,36 @@ const expectedParameterSchemaForArrayUnionRec =
                             }
                         }
                     }
-                ]
-            }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
-    };
+    }
+};
 
-const expectedParameterSchemaForArrayUnionBasicType = 
+const expectedParameterSchemaForArrayUnionRec =
     {
-        "type": "object",
-        "properties": {
-            "result": {
-                "anyOf": [
-                    {
-                        "type": "array",
-                        "items": {
-                            "required": [
-                                "name"
-                            ],
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                }
+    "type": "object",
+    "properties": {
+        "result": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
                             }
                         }
-                    },
-                    {
-                        "type": "string"
                     }
-                ]
-            }
-        }
-    };
-
-const expectedParameterSchemaForArrayOnly = 
-    {
-        "type": "object",
-        "properties": {
-            "result": {
-                "type": "array",
-                "items": {
+                },
+                {
                     "required": [
                         "name"
                     ],
@@ -340,17 +290,20 @@ const expectedParameterSchemaForArrayOnly =
                         }
                     }
                 }
-            }
+            ]
         }
-    };
+    }
+};
 
-const expectedParameterSchemaForRecUnionBasicType = 
+const expectedParameterSchemaForArrayUnionBasicType =
     {
-        "type": "object",
-        "properties": {
-            "result": {
-                "anyOf": [
-                    {
+    "type": "object",
+    "properties": {
+        "result": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
                         "required": [
                             "name"
                         ],
@@ -360,36 +313,115 @@ const expectedParameterSchemaForRecUnionBasicType =
                                 "type": "string"
                             }
                         }
-                    },
-                    {
+                    }
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        }
+    }
+};
+
+const expectedParameterSchemaForArrayOnly =
+    {
+    "type": "object",
+    "properties": {
+        "result": {
+            "type": "array",
+            "items": {
+                "required": [
+                    "name"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
                         "type": "string"
                     }
-                ]
+                }
             }
         }
-    };
+    }
+};
 
-const expectedParameterSchemaForRecUnionNull = 
+const expectedParameterSchemaForRecUnionBasicType =
     {
-        "type": "object",
-        "properties": {
-            "result": {
-                "anyOf": [
-                    {
-                        "required": [
-                            "name"
-                        ],
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            }
+    "type": "object",
+    "properties": {
+        "result": {
+            "anyOf": [
+                {
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
                         }
-                    },
-                    {
-                        "type": "null"
                     }
-                ]
-            }
+                },
+                {
+                    "type": "string"
+                }
+            ]
         }
-    };
+    }
+};
+
+const expectedParameterSchemaForRecUnionNull =
+    {
+    "type": "object",
+    "properties": {
+        "result": {
+            "anyOf": [
+                {
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        }
+    }
+};
+
+final readonly & map<anydata>[] expectedContentPartsForTextChunk = [
+    {"type": "text", "text": "How would you rate this text chunk content out of 10. "},
+    {
+        "type": "text",
+        "text": "Title: Tips for Growing a Beautiful Garden Content: " +
+        "Spring is the perfect time to start your garden. \n        Begin by preparing your soil with " +
+        "organic compost and ensure proper drainage. \n        Choose plants suitable for your climate zone, " +
+        "and remember to water them regularly. \n        Don't forget to mulch to retain moisture and prevent weeds."
+    },
+    {"type": "text", "text": "."}
+];
+
+final readonly & map<anydata>[] expectedContentPartsForTextChunkArray = [
+    {"type": "text", "text": "How would you rate these text chunks out of 10. "},
+    {
+        "type": "text",
+        "text": "Title: Tips for Growing a Beautiful Garden Content: " +
+        "Spring is the perfect time to start your garden. \n        Begin by preparing your soil with " +
+        "organic compost and ensure proper drainage. \n        Choose plants suitable for your climate zone, " +
+        "and remember to water them regularly. \n        Don't forget to mulch to retain moisture and prevent weeds."
+    },
+    {
+        "type": "text",
+        "text": "Title: Tips for Growing a Beautiful Garden Content: " +
+        "Spring is the perfect time to start your garden. \n        " +
+        "Begin by preparing your soil with organic compost and ensure proper drainage. \n        " +
+        "Choose plants suitable for your climate zone, and remember to water them regularly. \n        " +
+        "Don't forget to mulch to retain moisture and prevent weeds."
+    },
+    {"type": "text", "text": ". Thank you!"}
+];

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -221,7 +221,7 @@ function testGenerateMethodWithInvalidRecordType() returns ai:Error? {
     string msg = (<error>rating).message();
     test:assertTrue(rating is error);
     test:assertTrue(msg.includes(RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE),
-        string `expected error message to contain: ${RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE}, but found ${msg}`);
+            string `expected error message to contain: ${RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE}, but found ${msg}`);
 }
 
 type ProductNameArray ProductName[];
@@ -233,7 +233,6 @@ function testGenerateMethodWithInvalidRecordArrayType2() returns ai:Error? {
     test:assertTrue(rating is error);
     test:assertTrue((<error>rating).message().includes(ERROR_MESSAGE));
 }
-
 
 type Cricketers record {|
     string name;
@@ -301,7 +300,6 @@ function testGenerateMethodWithArrayUnionBasicType() returns error? {
     test:assertTrue(result is Cricketers3[]);
 }
 
-
 @test:Config
 function testGenerateMethodWithArrayUnionNull() returns error? {
     Cricketers4[]? result = check provider->generate(`Name 10 world class cricketers`);
@@ -316,7 +314,22 @@ function testGenerateMethodWithArrayUnionRecord() returns ai:Error? {
 
 @test:Config
 function testGenerateMethodWithArrayUnionRecord2() returns ai:Error? {
-   Cricketers7[]|Cricketers8|error result = provider->generate(`Name a random world class cricketer`);
+    Cricketers7[]|Cricketers8|error result = provider->generate(`Name a random world class cricketer`);
     test:assertTrue(result is Cricketers8);
 }
 
+@test:Config
+function testGenerateMethodWithTextChunk() returns error? {
+    ai:TextChunk chunk = {
+        content: string `Title: ${blog1.title} Content: ${blog1.content}`
+    };
+    ai:TextChunk[] chunks = [chunk, chunk];
+    int maxScore = 10;
+
+    int rating = check provider->generate(`How would you rate this text chunk content out of ${maxScore}. ${chunk}.`);
+    test:assertEquals(rating, 4);
+
+    ReviewArray result = check provider->generate(`How would you rate these text chunks out of ${maxScore}. ${chunks}. Thank you!`);
+    Review r = check review.fromJsonStringWithType();
+    test:assertEquals(result, [r, r]);
+}

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Ballerina"]
 distribution = "2201.12.0"
-keywords = ["Agent", "Model", "Provider", "Vendor/OpenAI", "Area/AI & Machine Learning", "Type/Connector"]
+keywords = ["Agent", "Model", "Provider", "Vendor/OpenAI", "Area/AI & Machine Learning", "Type/Library"]
 license = ["Apache-2.0"]
 icon="icon.png"
 name = "ai.openai"


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/wso2/product-integrator/issues/370

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [x] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix for ModelProvider.generate method with TextChunk input

This pull request fixes a failure in ModelProvider.generate when interpolating ai:TextChunk values into prompts, ensuring text chunks are treated as valid document content.

### Core changes
- update generateChatCreationContent to accept ai:Document and ai:Chunk insertion types.
- extend addDocumentContentPart to handle ai:TextChunk alongside ai:TextDocument; image handling preserved.
- unify prompt content assembly so text chunks and arrays of chunks are converted into the expected chat content parts.

### Tests
- add testGenerateMethodWithTextChunk to verify generate works with a single ai:TextChunk and with an array of ai:TextChunk, asserting correct parsed outputs.
- update test utilities and expected value constants to cover text-chunk scenarios and mock responses.

### Maintenance and configuration
- bump module version from 1.3.2 → 1.3.3 in Ballerina.toml and native artifact references.
- update compiler plugin and native library artifact paths to 1.3.3-SNAPSHOT.
- update Dependencies.toml to reflect dependency version changes.
- adjust package metadata keywords to use "Type/Library".

The change improves stability and compatibility of the model provider by expanding supported prompt insertion types and adding coverage to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->