### PR TITLE
chore: update default max token count to 4096

### DIFF
--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -20,7 +20,7 @@ import ballerina/jballerina.java;
 import ballerinax/openai.chat;
 
 const DEFAULT_OPENAI_SERVICE_URL = "https://api.openai.com/v1";
-const DEFAULT_MAX_TOKEN_COUNT = 512;
+const DEFAULT_MAX_TOKEN_COUNT = 4096;
 const DEFAULT_TEMPERATURE = 0.7d;
 
 # ModelProvider is a client class that provides an interface for interacting with OpenAI Large Language Models.


### PR DESCRIPTION
## Purpose
Increase the default maximum output token count (`DEFAULT_MAX_TOKEN_COUNT`) from 512 to 4096 to allow models to generate longer responses by default.
The previous value of 512 was overly conservative for all supported OpenAI models. The new value of 4096 is the safest increase, as it is the lowest max output token limit across all models in the `OPEN_AI_MODEL_NAMES` enum (GPT-3.5 Turbo and GPT-4 Turbo support up to 4,096).

**References**

https://developers.openai.com/api/docs/models/gpt-4-turbo

Fixes:
## Examples
```ballerina
// Before: responses were limited to 512 tokens by default, often causing truncated output
final ModelProvider provider = check new (apiKey, GPT_4O, serviceUrl);

// After: responses can now use up to 4096 tokens by default, reducing truncation issues
// Users can still override via the maxTokens parameter if needed
final ModelProvider provider = check new (apiKey, GPT_4O, serviceUrl, maxTokens = 8192);





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request increases the default maximum token count for the OpenAI module from 512 to 4096, enabling models to generate longer responses by default. The change updates the `DEFAULT_MAX_TOKEN_COUNT` constant in `ballerina/model-provider.bal` to align with the lowest maximum output token limit among supported OpenAI models (GPT-3.5 Turbo and GPT-4 Turbo). Callers can still customize token limits by passing the `maxTokens` parameter when needed.

## Changes

- Updated `DEFAULT_MAX_TOKEN_COUNT` constant from `512` to `4096` in `ballerina/model-provider.bal`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->