### PR TITLE
Enable parallel tool calling functionality in model provider. (Issue: 1685)

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -146,7 +146,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -296,7 +296,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -107,7 +107,19 @@ public isolated distinct client class ModelProvider {
         };
         boolean supportsToolCalls = isToolCallSupported(self.modelType);
         if supportsToolCalls && tools.length() > 0 {
-            request.functions = tools;
+            chat:ChatCompletionTool[] chatTools = [];
+            foreach ai:ChatCompletionFunctions tool in tools {
+                chat:FunctionParameters|error params = tool.parameters.cloneWithType();
+                chatTools.push({
+                    'type: "function",
+                    'function: {
+                        name: tool.name,
+                        description: tool.description,
+                        parameters: params is chat:FunctionParameters ? params : ()
+                    }
+                });
+            }
+            request.tools = chatTools;
             span.addTools(tools);
         }
 
@@ -191,8 +203,12 @@ public isolated distinct client class ModelProvider {
                     content: check getChatMessageStringContent(message.content),
                     name: message.name
                 });
-            } else if message is ai:ChatFunctionMessage|ai:ChatAssistantMessage {
-                chatCompletionRequestMessages.push(message);
+            } else if message is ai:ChatFunctionMessage {
+                chatCompletionRequestMessages.push(<chat:ChatCompletionRequestToolMessage>{
+                    role: "tool",
+                    tool_call_id: message.id ?: message.name,
+                    content: message.content ?: ""
+                });
             }
         }
         return chatCompletionRequestMessages;
@@ -204,11 +220,14 @@ public isolated distinct client class ModelProvider {
         boolean supportsToolCalls = isToolCallSupported(self.modelType);
         ai:FunctionCall[]? toolCalls = message.toolCalls;
         if supportsToolCalls && toolCalls is ai:FunctionCall[] {
-            ai:FunctionCall functionCall = toolCalls[0];
-            assistantMessage.function_call = {
-                name: functionCall.name,
-                arguments: functionCall.arguments.toJsonString()
-            };
+            assistantMessage.tool_calls = toolCalls.map(tc => <chat:ChatCompletionMessageToolCall>{
+                id: tc.id ?: "",
+                'type: "function",
+                'function: {
+                    name: tc.name,
+                    arguments: tc.arguments.toJsonString()
+                }
+            });
         } else if !supportsToolCalls && toolCalls is ai:FunctionCall[] {
             assistantMessage.content = formatFunctionCallToJsonWithFences(toolCalls[0]);
         }
@@ -228,15 +247,19 @@ public isolated distinct client class ModelProvider {
             ai:ChatAssistantMessage chatAssistantMessage = {role: ai:ASSISTANT};
             if hasToolCallResponse {
                 chatAssistantMessage.content = message?.content;
-                chat:ChatCompletionRequestAssistantMessage_function_call? functionCall = message?.function_call;
-                if functionCall is chat:ChatCompletionRequestAssistantMessage_function_call {
-                    json arguments = check functionCall.arguments.fromJsonString();
-                    chatAssistantMessage.toolCalls = [
-                        {
-                            name: functionCall.name,
-                            arguments: check arguments.cloneWithType()
-                        }
-                    ];
+                chat:ChatCompletionMessageToolCall[]? toolCalls = message?.tool_calls;
+                if toolCalls is chat:ChatCompletionMessageToolCall[] && toolCalls.length() > 0 {
+                    ai:FunctionCall[] functionCalls = [];
+                    foreach chat:ChatCompletionMessageToolCall tc in toolCalls {
+                        json arguments = check tc.'function.arguments.fromJsonString();
+                        map<json>? args = check arguments.cloneWithType();
+                        functionCalls.push({
+                            id: tc.id,
+                            name: tc.'function.name,
+                            arguments: args
+                        });
+                    }
+                    chatAssistantMessage.toolCalls = functionCalls;
                 }
                 return chatAssistantMessage;
             }

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -25,18 +25,25 @@ service /llm on new http:Listener(8080) {
         test:assertEquals(payload.model, GPT_4O);
         chat:ChatCompletionRequestMessage[] messages = check (check payload.messages).fromJsonWithType();
         chat:ChatCompletionRequestMessage message = messages[0];
+        test:assertEquals(message.role, "user");
 
-        chat:ChatCompletionRequestUserMessageContentPart[]? content = check message["content"].ensureType();
-        if content is () {
-            test:assertFail("Expected content in the payload");
+        json contentJson = check message.toJson().content;
+
+        // chat() sends content as a plain string; generate() sends a content parts array
+        if contentJson is string {
+            chat:ChatCompletionTool[]? tools = check (check payload.tools).fromJsonWithType();
+            if tools is () || tools.length() == 0 {
+                test:assertFail("No tools in the payload");
+            }
+            return getParallelToolCallResponse();
         }
 
+        chat:ChatCompletionRequestUserMessageContentPart[] content = check contentJson.fromJsonWithType();
         chat:ChatCompletionRequestUserMessageContentPart initialContentPart = content[0];
         TextContentPart initialTextContent = check initialContentPart.ensureType();
         string initialText = initialTextContent.text;
         test:assertEquals(content, getExpectedContentParts(initialText),
                 string `Test failed for prompt with initial content, ${initialText}`);
-        test:assertEquals(message.role, "user");
         chat:ChatCompletionTool[]? tools = check (check payload.tools).fromJsonWithType();
         if tools is () || tools.length() == 0 {
             test:assertFail("No tools in the payload");

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -265,6 +265,37 @@ isolated function getTheMockLLMResult(string message) returns string {
     return "INVALID";
 }
 
+isolated function getParallelToolCallResponse() returns chat:CreateChatCompletionResponse => {
+    id: "test-parallel-id",
+    'object: "chat.completion",
+    created: 1234567890,
+    model: "gpt-4o",
+    choices: [
+        {
+            finish_reason: "tool_calls",
+            index: 0,
+            logprobs: (),
+            message: {
+                content: (),
+                refusal: (),
+                role: "assistant",
+                tool_calls: [
+                    {
+                        id: "call_weather",
+                        'type: "function",
+                        'function: {name: "getWeather", arguments: "{\"city\": \"London\"}"}
+                    },
+                    {
+                        id: "call_time",
+                        'type: "function",
+                        'function: {name: "getTime", arguments: "{\"city\": \"London\"}"}
+                    }
+                ]
+            }
+        }
+    ]
+};
+
 isolated function getTestServiceResponse(string content) returns chat:CreateChatCompletionResponse =>
     {
     id: "test-id",

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -333,3 +333,23 @@ function testGenerateMethodWithTextChunk() returns error? {
     Review r = check review.fromJsonStringWithType();
     test:assertEquals(result, [r, r]);
 }
+
+@test:Config
+function testParallelToolCalling() returns ai:Error? {
+    ai:ChatCompletionFunctions[] tools = [
+        { name: "getWeather", description: "Get weather for a city",
+          parameters: { "type": "object", "properties": { "city": { "type": "string" } } } },
+        { name: "getTime", description: "Get current time for a city",
+          parameters: { "type": "object", "properties": { "city": { "type": "string" } } } }
+    ];
+
+    ai:ChatAssistantMessage result = check provider->chat(
+        [{ role: ai:USER, content: "What is the weather and time in London?" }],
+        tools
+    );
+
+    ai:FunctionCall[]? toolCalls = result.toolCalls;
+    test:assertTrue(toolCalls is ai:FunctionCall[]);
+    test:assertTrue((<ai:FunctionCall[]>toolCalls).length() > 1);
+}
+


### PR DESCRIPTION
## Purpose

Fixes #1685 — Add parallel tool calling support by migrating from the legacy OpenAI `functions` API to the modern `tools` API.

Previously, the connector used the deprecated `functions`/`function_call` fields which only supported a single tool call per model response turn. This change switches to the `tools`/`tool_calls` fields, enabling the model to return multiple tool calls in a single response (parallel tool calling).

Key changes:
- Replaced `request.functions` with `request.tools` using `chat:ChatCompletionTool[]`
- Replaced single `function_call` response reading with `tool_calls[]` array iteration
- Updated assistant messages to echo back all tool calls with their `id`s
- Updated tool result messages to use role `"tool"` with `tool_call_id` instead of role `"function"`

## Examples

```ballerina
ai:ChatCompletionFunctions[] tools = [
    { name: "getWeather", description: "Get weather for a city",
      parameters: { "type": "object", "properties": { "city": { "type": "string" } } } },
    { name: "getTime", description: "Get current time for a city",
      parameters: { "type": "object", "properties": { "city": { "type": "string" } } } }
];

ai:ChatAssistantMessage result = check provider->chat(
    [{ role: ai:USER, content: "What is the weather and time in London?" }],
    tools
);

// result.toolCalls now contains both getWeather and getTime calls in a single response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary

This PR enables parallel tool calling functionality in the OpenAI model provider connector by migrating from the legacy OpenAI functions API to the modern tools API.

### Key Changes

**Core Functionality Updates**
- Refactored `ModelProvider.chat` to build and assign OpenAI-compatible tool definitions to `request.tools` instead of `request.functions`, using the standardized `ChatCompletionTool[]` format with `type: "function"` and nested function payloads
- Updated tool call serialization in `buildRequestAssistantMessage` to map multiple function calls into `assistantMessage.tool_calls` with proper identifiers and metadata, replacing the single-call legacy structure
- Modified tool call deserialization in `convertResponseToAssistantMessage` to iterate over `tool_calls[]` arrays from OpenAI responses, allowing multiple tools to be invoked in a single model response
- Enhanced message handling in `prepareCompletionRequestMessages` to properly process tool messages using the new format with `role: "tool"` and `tool_call_id` attributes

**Test Coverage**
- Added test infrastructure to validate parallel tool calling by introducing a new test case that verifies multiple tools can be called within a single response
- Added helper utilities to simulate parallel tool call responses with multiple function calls (e.g., `getWeather` and `getTime`)
- Updated test service to handle the new tools request format and content parsing logic

**Dependencies**
- Updated Ballerina dependency versions for improved compatibility and stability

### Impact
The connector now supports modern parallel tool calling patterns, enabling more flexible and efficient multi-tool orchestration in AI chat workflows. The changes maintain backward compatibility through proper message handling while leveraging the improved OpenAI tools API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->