### PR TITLE
Clarify Overview so the Central summary distinguishes ai.openai

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -1,8 +1,6 @@
 ## Overview
 
-OpenAI provides powerful AI models for natural language processing, image generation, and other advanced tasks.
-
-The OpenAI connector offers APIs for connecting with OpenAI Large Language Models (LLMs), enabling the integration of advanced conversational AI, text generation, and language processing capabilities into applications.
+The `ai.openai` module provides OpenAI-backed `ModelProvider` and `EmbeddingProvider` implementations for the [`ballerina/ai`](https://central.ballerina.io/ballerina/ai/latest) agent framework. Use it to drive OpenAI chat models (GPT-4o, GPT-4, GPT-3.5) and text-embedding models from Ballerina AI agents, RAG pipelines, and other `ai`-module abstractions — rather than calling the OpenAI REST API directly.
 
 ### Key Features
 


### PR DESCRIPTION
### Purpose

The first paragraph of the package Overview is what Ballerina Central stores as the package **summary**, and that summary is the `description` the Ballerina Copilot **library-search tool** returns to the agent when it picks a library. Today `ai.openai` and the standalone `openai.chat` connector both open with a generic OpenAI vendor blurb, so their summaries are nearly identical and an agent cannot tell them apart.

### Change

Rewrite the Overview's first paragraph in `ballerina/README.md` to state what this module uniquely provides — OpenAI-backed `ModelProvider` / `EmbeddingProvider` implementations for the [`ballerina/ai`](https://central.ballerina.io/ballerina/ai/latest) agent framework — and merge away the now-redundant generic second paragraph. Only the Overview intro changes; **Key Features** and everything below are untouched.

Grounded in the actual API (`ModelProvider` `*ai:ModelProvider`, `EmbeddingProvider` `*ai:EmbeddingProvider`).

> Draft: opening for review of wording before finalizing. Part of a wider pass to disambiguate OpenAI-related package summaries (`ai.openai` vs `openai.chat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)